### PR TITLE
Working Demo link

### DIFF
--- a/info.md
+++ b/info.md
@@ -13,7 +13,7 @@
 
 ### Online Demo OWASP-SKF
 
-- [OWASP-SKF Online Demo](https://beta.securityknowledgeframework.org "OWASP-SKF Online Demo")
+- [OWASP-SKF Online Demo](https://securityknowledgeframework.org/demo.php "OWASP-SKF Online Demo")
 - username: admin
 - password: test-skf
 


### PR DESCRIPTION
The demo link currently on the project page on owasp.org does not work but the one on the project source code does. Just replacing it with that link.