### PR TITLE
Update to use current logo

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ level: 4
 url: "https://owasp.org/www-project-security-knowledge-framework/"
 
 ---
-[![SKF Logo](https://www.securityknowledgeframework.org/img/banner-wiki-owasp.jpg)](https://www.securityknowledgeframework.org/) 
+[![SKF Logo](https://www.securityknowledgeframework.org/images/site-skf/logos/logo.svg)](https://www.securityknowledgeframework.org/) 
 
 <br>Project status details:<br>
 [![Join the chat at https://gitter.im/Security-Knowledge-Framework/Lobby](https://badges.gitter.im/Security-Knowledge-Framework/Lobby.svg)](https://gitter.im/Security-Knowledge-Framework/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
Noticed the logo was not up-to-date and, as SKF is about to be a spotlight project, I thought it might be good to update this.